### PR TITLE
rename duplicate in-4 site to kr-4

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -173,10 +173,6 @@ sites:
     url:  https://in-4-mirror.chaotic.cx/no-failover/chaotic-aur/lastupdate
     assignees:
       - a0xz
-  - name: Silky.Network - in-4
-    url:  https://kr-4-mirror.chaotic.cx/no-failover/chaotic-aur/lastupdate
-    assignees:
-      - a0xz
   - name: Silky.Network - in-5
     url:  https://in-5-mirror.chaotic.cx/no-failover/chaotic-aur/lastupdate
     assignees:
@@ -195,6 +191,10 @@ sites:
       - a0xz
   - name: Silky.Network - kr-2
     url:  https://kr-2-mirror.chaotic.cx/no-failover/chaotic-aur/lastupdate
+    assignees:
+      - a0xz
+  - name: Silky.Network - kr-4
+    url:  https://kr-4-mirror.chaotic.cx/no-failover/chaotic-aur/lastupdate
     assignees:
       - a0xz
   - name: Silky.Network - mx


### PR DESCRIPTION
It had the same name as another monitor, which made it buggy and spam status messages.